### PR TITLE
🎨 Palette: Clean up CLI spinner output behavior

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-03 - CLI Spinner Overwrite
+**Learning:** Terminal output streams that continually append progress updates (like spinners or percentage counts) create cluttered, unreadable UX in CLI tools.
+**Action:** In Windows Batch, capture a true Carriage Return character (using `for /f %%A in ('copy /Z "%~f0" nul') do set "CR=%%A"`) and prepend it to progress strings (`!CR!Scanning...`) to force in-place line overwriting for a clean update loop.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal EnableDelayedExpansion
+for /f %%A in ('copy /Z "%~f0" nul') do set "CR=%%A"
 :: SizeSpy - Version 1.7.7 (Spinner-based scanning feedback)
 :: Author: Rydell Hall
 
@@ -82,7 +83,7 @@ for /F "delims=" %%F in ('dir /S /B /A:-D "%drive%\"') do (
     set /a progress+=1
     set /a spinpos=(spinpos+1) %% 4
     call set "sym=%%spinner:~!spinpos!,1%%"
-    <nul set /p=Scanning [!progress!/!total_files!] !sym!     
+    <nul set /p=!CR!Scanning [!progress!/!total_files!] !sym!
 )
 echo.
 echo Total qualifying files: !progress!


### PR DESCRIPTION
💡 **What:** The progress spinner logic in `SizeSpy.bat` was updated to overwrite the terminal line in place rather than repeatedly appending text.
🎯 **Why:** The previous behavior caused the terminal to quickly become cluttered with scanning output. By prepending a true Carriage Return (`!CR!`) character, the spinner now functions as a clean, single-line progress indicator, significantly improving the CLI user experience.
📸 **Before/After:** Not applicable (terminal change, but the stream is now a single updating line).
♿ **Accessibility:** Reduces visual noise and screen reader repetition during long scans.

---
*PR created automatically by Jules for task [7336098618426392046](https://jules.google.com/task/7336098618426392046) started by @GhostwheeI*