### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Batch File Loop Performance
+**Learning:** `call` statements in a tight batch file `for` loop have an enormous performance penalty due to context switching overhead in the CMD interpreter. In `SizeSpy.bat`, the `call set "sym=%%spinner:~!spinpos!,1%%"` command executes on every single file scanned, blocking the loop significantly.
+**Action:** Replace dynamic `call set` or `call :label` operations in `for` loops with mathematical modulus operations and inline if-statements (or substring extraction using delayed expansion tricks) where possible to drastically improve scan speed on large numbers of files.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -80,9 +80,20 @@ for /F "delims=" %%F in ('dir /S /B /A:-D "%drive%\"') do (
     set "size=%%~zF"
     if !size! geq !min_bytes! echo !size! "%%F" >> "%filetmp%"
     set /a progress+=1
-    set /a spinpos=(spinpos+1) %% 4
-    call set "sym=%%spinner:~!spinpos!,1%%"
-    <nul set /p=Scanning [!progress!/!total_files!] !sym!     
+
+    :: ⚡ Bolt: Performance optimization
+    :: Removed expensive `call set` and console I/O on every iteration.
+    :: Modulus check ensures we only update the spinner every 100 files,
+    :: eliminating massive context-switch and I/O bottlenecks.
+    set /a "mod=progress %% 100"
+    if !mod! equ 0 (
+        set /a spinpos=(spinpos+1) %% 4
+        if !spinpos! equ 0 set "sym=-"
+        if !spinpos! equ 1 set "sym=\"
+        if !spinpos! equ 2 set "sym=|"
+        if !spinpos! equ 3 set "sym=/"
+        <nul set /p=Scanning [!progress!/!total_files!] !sym!
+    )
 )
 echo.
 echo Total qualifying files: !progress!


### PR DESCRIPTION
💡 **What:** Replaced the expensive `call set "sym=%%spinner:~!spinpos!,1%%"` command and the associated console I/O inside the tight file scanning loop with a `modulus 100` check and direct `if` evaluations.

🎯 **Why:** In Windows Batch scripts, the `call set` statement evaluates in a sub-process-like manner, incurring significant context-switching overhead. Doing this—along with console I/O (`<nul set /p=...`)—on every single file iteration causes the script execution to be heavily bottlenecked.

📊 **Impact:** This drastically reduces the overhead per file iteration, skipping the evaluation and console write for 99% of scanned files. Scans over directories with tens of thousands of files will finish significantly faster, making the script substantially more efficient.

🔬 **Measurement:** Execute `SizeSpy.bat` on a large directory (e.g., `C:\Windows`) before and after the change. Observe the significant reduction in total scanning time.

---
*PR created automatically by Jules for task [18245945949788506056](https://jules.google.com/task/18245945949788506056) started by @GhostwheeI*