### PR TITLE
🎨 Palette: Contextual CLI input prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-05 - Contextual CLI Prompts
+**Learning:** Users lack visibility into their current configuration when updating settings in sequential, interactive CLI prompts, leading to higher cognitive load as they must memorize previous states before initiating a change.
+**Action:** Always inject the existing/current value directly into the input prompt string (e.g., `[Current: X]`) before asking the user for a new value, turning blind inputs into contextual updates.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -34,15 +34,15 @@ if /I "%choice%"=="Q" goto end
 goto mainmenu
 
 :setdrives
-set /p scan_drives=Enter drive letters (comma-separated, e.g. C,D,E): 
+set /p scan_drives=Enter drive letters (comma-separated, e.g. C,D,E) [Current: %scan_drives%]:
 goto mainmenu
 
 :setminsize
-set /p min_size_mb=Enter minimum file/folder size in MB: 
+set /p min_size_mb=Enter minimum file/folder size in MB [Current: %min_size_mb%]:
 goto mainmenu
 
 :setlimit
-set /p display_limit=Enter number of items to display: 
+set /p display_limit=Enter number of items to display [Current: %display_limit%]:
 goto mainmenu
 
 :togglereport
@@ -82,7 +82,7 @@ for /F "delims=" %%F in ('dir /S /B /A:-D "%drive%\"') do (
     set /a progress+=1
     set /a spinpos=(spinpos+1) %% 4
     call set "sym=%%spinner:~!spinpos!,1%%"
-    <nul set /p=Scanning [!progress!/!total_files!] !sym!     
+    <nul set /p=Scanning [!progress!/!total_files!] !sym!
 )
 echo.
 echo Total qualifying files: !progress!


### PR DESCRIPTION
💡 **What:** Added the current value of variables into the CLI input prompts within `SizeSpy.bat` (e.g. `[Current: C]`).

🎯 **Why:** Users lacked visibility into their current configuration when updating settings. Displaying the current value removes the need to memorize previous states before initiating a change, reducing cognitive load and making the interface more intuitive.

📸 **Before/After:**
**Before:**
`Enter drive letters (comma-separated, e.g. C,D,E): `
**After:**
`Enter drive letters (comma-separated, e.g. C,D,E) [Current: C]: `

♿ **Accessibility:** Reduces cognitive load for all users, particularly aiding those with short-term memory challenges by eliminating blind inputs.

---
*PR created automatically by Jules for task [9131516146044983962](https://jules.google.com/task/9131516146044983962) started by @GhostwheeI*