### PR TITLE
⚡ Bolt: Optimize SizeSpy scan times by removing duplicate I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Double I/O Scanning Bottleneck
+**Learning:** Pre-computing `total_files` by running a full `dir /S /B` scan across an entire drive just for a progress bar completely halves the performance of the script by doubling disk I/O operations.
+**Action:** Avoid traversing large file trees purely for metric collection; rely on indeterminate progress indicators (like a simple spinner or running count) when working with massive I/O operations.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -67,10 +67,7 @@ del "%filetmp%" 2>nul & del "%fileout%" 2>nul
 
 for /f %%t in ('powershell -nologo -command "(Get-Date).ToString(\"HH:mm:ss\")"') do set start_time=%%t
 
-:: Precompute total files for better progress tracking
-set /a total_files=0
-for /F %%F in ('dir /S /B /A:-D "%drive%\" ^| find /C /V ""') do set total_files=%%F
-
+:: Removed duplicate total_files precomputation to avoid doubling I/O wait times
 set /a progress=0
 set "spinner=-\\|/"
 set /a spinpos=0
@@ -82,7 +79,7 @@ for /F "delims=" %%F in ('dir /S /B /A:-D "%drive%\"') do (
     set /a progress+=1
     set /a spinpos=(spinpos+1) %% 4
     call set "sym=%%spinner:~!spinpos!,1%%"
-    <nul set /p=Scanning [!progress!/!total_files!] !sym!     
+    <nul set /p=Scanning [!progress!] !sym!
 )
 echo.
 echo Total qualifying files: !progress!


### PR DESCRIPTION
💡 **What**: Removed the preliminary `dir /S /B` traversal pass that existed solely to count `total_files` for the progress indicator. Updated the progress UI to show a simple running count (`[!progress!]`) alongside the existing spinner.

🎯 **Why**: The previous implementation performed a full recursive traversal (`dir /S /B`) across the entire specified drive just to find out the total number of files, only to immediately perform the exact same traversal again to process the files. This double pass effectively doubled the disk I/O wait times and execution duration.

📊 **Impact**: Expected execution time reduction of ~50%, primarily significantly reducing disk I/O operations by completely eliminating an entire recursive file system search pass. 

🔬 **Measurement**: Execute `SizeSpy.bat` on a large test directory or drive and measure total execution time compared to previous version. You will notice it starts processing files immediately rather than hanging on the initial file count.

---
*PR created automatically by Jules for task [17622892998150696241](https://jules.google.com/task/17622892998150696241) started by @GhostwheeI*