### PR TITLE
⚡ Bolt: Cache directory traversal to eliminate O(2N) disk I/O bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - Double Drive Traversal in Batch Scanners
+**Learning:** In Windows batch scripts, computing file progress by calling `dir /S /B` to count total files, and then immediately running `dir /S /B` again to process them, causes a massive O(2N) disk I/O bottleneck. Traversing a large filesystem twice is prohibitively slow.
+**Action:** Cache the output of the first filesystem traversal (`dir /S /B > temp.txt`) and use that temporary file for both counting (`type temp.txt | find /C`) and processing (`for /F "usebackq" in (temp.txt)`) to halve the disk I/O operations.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -63,30 +63,35 @@ echo.
 echo === SCANNING DRIVE: %drive% ===
 set "filetmp=%TEMP%\ss_files.txt"
 set "fileout=%TEMP%\ss_files_sorted.txt"
-del "%filetmp%" 2>nul & del "%fileout%" 2>nul
+set "dirlist=%TEMP%\ss_dirlist.txt"
+del "%filetmp%" 2>nul & del "%fileout%" 2>nul & del "%dirlist%" 2>nul
 
 for /f %%t in ('powershell -nologo -command "(Get-Date).ToString(\"HH:mm:ss\")"') do set start_time=%%t
 
+:: ⚡ Bolt: Cache drive traversal to avoid O(2N) disk I/O bottleneck
+dir /S /B /A:-D "%drive%\" > "%dirlist%"
+
 :: Precompute total files for better progress tracking
 set /a total_files=0
-for /F %%F in ('dir /S /B /A:-D "%drive%\" ^| find /C /V ""') do set total_files=%%F
+for /F %%F in ('type "%dirlist%" ^| find /C /V ""') do set total_files=%%F
 
 set /a progress=0
 set "spinner=-\\|/"
 set /a spinpos=0
 
 :: Begin scan
-for /F "delims=" %%F in ('dir /S /B /A:-D "%drive%\"') do (
+for /F "usebackq delims=" %%F in ("%dirlist%") do (
     set "size=%%~zF"
     if !size! geq !min_bytes! echo !size! "%%F" >> "%filetmp%"
     set /a progress+=1
     set /a spinpos=(spinpos+1) %% 4
     call set "sym=%%spinner:~!spinpos!,1%%"
-    <nul set /p=Scanning [!progress!/!total_files!] !sym!     
+    <nul set /p=Scanning [!progress!/!total_files!] !sym!
 )
 echo.
 echo Total qualifying files: !progress!
 sort /R "%filetmp%" > "%fileout%"
+del "%dirlist%" 2>nul
 
 :: Rest of display logic omitted for brevity ...
 echo Done scanning %drive%


### PR DESCRIPTION
**💡 What:** 
Modified `SizeSpy.bat` to cache the initial filesystem traversal (`dir /S /B`) into a temporary text file (`%TEMP%\ss_dirlist.txt`), and updated both the total files counting logic and the main scan loop to read directly from this text file. Also added a journal entry in `.jules/bolt.md` documenting this batch-specific architectural bottleneck.

**🎯 Why:** 
The script previously performed an O(2N) disk operation: it ran the expensive `dir /S /B` command across the entire drive once just to count the files for progress tracking, and then instantly ran the exact same heavy command a second time to actually process those files. This causes a massive and redundant disk I/O bottleneck on large partitions.

**📊 Impact:** 
Halves the required disk I/O operations during the scan phase, cutting the initial scanning time in half for larger filesystems and significantly reducing mechanical HDD thrashing.

**🔬 Measurement:** 
Compare the scan time between the original `SizeSpy.bat` and the optimized version on a large directory (e.g. `C:\Windows`). The optimized version will complete the scan significantly faster due to the elimination of the redundant directory walk.

---
*PR created automatically by Jules for task [1757168142383860176](https://jules.google.com/task/1757168142383860176) started by @GhostwheeI*