### PR TITLE
🎨 Palette: Improve CLI prompt UX with current values and safe defaults

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [CLI Prompt Variable State Persistence]
+**Learning:** In Windows batch scripts (`set /p`), input variables retain their previous values if the user presses enter (providing empty input). This can cause confusion and accidental configuration overrides if the variable is not cleared prior to prompting.
+**Action:** Always clear the input variable (`set "input="`) before a `set /p` prompt, and assign the new value conditionally (`if defined input set "var=%input%"`). Additionally, it greatly improves UX to show the current variable value in the prompt context like `[Current: %var%]`.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -34,15 +34,21 @@ if /I "%choice%"=="Q" goto end
 goto mainmenu
 
 :setdrives
-set /p scan_drives=Enter drive letters (comma-separated, e.g. C,D,E): 
+set "input="
+set /p "input=Enter drive letters (comma-separated, e.g. C,D,E) [Current: %scan_drives%]: "
+if defined input set "scan_drives=%input%"
 goto mainmenu
 
 :setminsize
-set /p min_size_mb=Enter minimum file/folder size in MB: 
+set "input="
+set /p "input=Enter minimum file/folder size in MB [Current: %min_size_mb%]: "
+if defined input set "min_size_mb=%input%"
 goto mainmenu
 
 :setlimit
-set /p display_limit=Enter number of items to display: 
+set "input="
+set /p "input=Enter number of items to display [Current: %display_limit%]: "
+if defined input set "display_limit=%input%"
 goto mainmenu
 
 :togglereport
@@ -82,7 +88,7 @@ for /F "delims=" %%F in ('dir /S /B /A:-D "%drive%\"') do (
     set /a progress+=1
     set /a spinpos=(spinpos+1) %% 4
     call set "sym=%%spinner:~!spinpos!,1%%"
-    <nul set /p=Scanning [!progress!/!total_files!] !sym!     
+    <nul set /p=Scanning [!progress!/!total_files!] !sym!
 )
 echo.
 echo Total qualifying files: !progress!


### PR DESCRIPTION
💡 **What:** Added current configuration values to user prompts in `SizeSpy.bat` and implemented safe variable handling for empty inputs.
🎯 **Why:** Previously, users couldn't see their current settings when asked to change them, and pressing enter without typing could unexpectedly overwrite variables or fail silently due to batch `set /p` retaining previous state on empty input. Now, they see `[Current: X]` and can safely press Enter to keep the existing value.
📸 **Before/After:** Not applicable (CLI output only).
♿ **Accessibility:** Improved cognitive accessibility by making the current system state explicitly visible during configuration, reducing the need for users to remember their settings.

---
*PR created automatically by Jules for task [13027629970350293785](https://jules.google.com/task/13027629970350293785) started by @GhostwheeI*