### PR TITLE
🎨 Palette: [CLI UX prompt improvements]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - CLI Variable Persistence UX
+**Learning:** In Windows batch scripts, input variables prompted via `set /p` persist their previous values if the user enters empty input (e.g. just presses Enter). This can lead to unexpected behavior and a poor user experience. Also, providing context like `[Current: %var%]` drastically improves the UX of text-based configuration menus.
+**Action:** When working on Windows CLI tools, always clear temporary input variables before prompting, and use fallback logic (`if not "%new_val%"==""`) to preserve existing values. Always display the current value when prompting for a new one.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -24,6 +24,7 @@ echo.
 echo    [R] Run Scan
 
 echo    [Q] Quit
+set "choice="
 set /p choice=Select an option: 
 if /I "%choice%"=="1" goto setdrives
 if /I "%choice%"=="2" goto setminsize
@@ -34,15 +35,21 @@ if /I "%choice%"=="Q" goto end
 goto mainmenu
 
 :setdrives
-set /p scan_drives=Enter drive letters (comma-separated, e.g. C,D,E): 
+set "new_scan_drives="
+set /p new_scan_drives=Enter drive letters (comma-separated, e.g. C,D,E) [Current: %scan_drives%]:
+if not "%new_scan_drives%"=="" set "scan_drives=%new_scan_drives%"
 goto mainmenu
 
 :setminsize
-set /p min_size_mb=Enter minimum file/folder size in MB: 
+set "new_min_size_mb="
+set /p new_min_size_mb=Enter minimum file/folder size in MB [Current: %min_size_mb%]:
+if not "%new_min_size_mb%"=="" set "min_size_mb=%new_min_size_mb%"
 goto mainmenu
 
 :setlimit
-set /p display_limit=Enter number of items to display: 
+set "new_display_limit="
+set /p new_display_limit=Enter number of items to display [Current: %display_limit%]:
+if not "%new_display_limit%"=="" set "display_limit=%new_display_limit%"
 goto mainmenu
 
 :togglereport


### PR DESCRIPTION
🎨 Palette: [CLI UX prompt improvements]

What: Improved the user experience of configuring options in the SizeSpy CLI. Added a display of the current value before prompting for new input and fixed a standard batch bug where hitting enter without typing would accidentally append to or reuse previous inputs.
Why: Previously, if a user wanted to keep the current value of an option, they had to remember it and retype it, or if they accidentally hit enter, it could lead to unexpected behavior. This makes the tool much more intuitive to use.
Before/After:
  Before: `Enter drive letters (comma-separated, e.g. C,D,E): `
  After: `Enter drive letters (comma-separated, e.g. C,D,E) [Current: C]: `
Accessibility: Reduced cognitive load by displaying current application state directly in the interactive prompts.

---
*PR created automatically by Jules for task [16773262871221278253](https://jules.google.com/task/16773262871221278253) started by @GhostwheeI*