### PR TITLE
⚡ Bolt: [performance improvement] Throttle SizeSpy scanning loop output and eliminate `call` overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Throttling CLI output in Windows Batch files
+**Learning:** In Windows batch scripts, frequent console writes (like `<nul set /p=`) inside tight loops cause massive I/O bottlenecks. Additionally, using `call` (e.g. `call set` for dynamic strings) inside a loop is very CPU bound because it creates a new environment context per iteration.
+**Action:** Mitigate this by explicitly throttling UI updates using modulo math (e.g. `set /a "update_ui=progress %% 100"`) and bypass `call` using nested `if` statements for logic inside loops to significantly reduce overhead.

--- a/SizeSpy.bat
+++ b/SizeSpy.bat
@@ -80,9 +80,15 @@ for /F "delims=" %%F in ('dir /S /B /A:-D "%drive%\"') do (
     set "size=%%~zF"
     if !size! geq !min_bytes! echo !size! "%%F" >> "%filetmp%"
     set /a progress+=1
-    set /a spinpos=(spinpos+1) %% 4
-    call set "sym=%%spinner:~!spinpos!,1%%"
-    <nul set /p=Scanning [!progress!/!total_files!] !sym!     
+    set /a "update_ui=progress %% 100"
+    if !update_ui! equ 0 (
+        set /a spinpos=(spinpos+1) %% 4
+        if !spinpos! equ 0 set "sym=-"
+        if !spinpos! equ 1 set "sym=\"
+        if !spinpos! equ 2 set "sym=|"
+        if !spinpos! equ 3 set "sym=/"
+        <nul set /p=Scanning [!progress!/!total_files!] !sym!
+    )
 )
 echo.
 echo Total qualifying files: !progress!


### PR DESCRIPTION
💡 **What**: Refactored the core scanning loop in `SizeSpy.bat`. Implemented a modulo-based UI throttle that updates the scanner spinner only once every 100 files, instead of doing it for every single file. Eliminated the `call set "sym=%%spinner:~!spinpos!,1%%"` line within the loop, replacing it with hardcoded `if` evaluations to prevent continuous execution environment resets.

🎯 **Why**: In Windows Batch scripting, continuous outputs like `<nul set /p=` create severe I/O bottlenecks inside fast execution loops. Even more critical, utilizing `call` inside loops (such as `call set`) introduces immense CPU overhead because it generates a brand new command execution environment every iteration. Removing these significantly trims execution time without sacrificing functionality.

📊 **Impact**: Expected substantial reduction in total drive scan execution time. I/O overhead drops by 99% (doing 1 print out of 100) and CPU overhead falls drastically due to the elimination of the loop-based `call`.

🔬 **Measurement**: Run `SizeSpy.bat`, start scanning a large directory and verify that it scans considerably faster and does not hang the system. Also, observe that the `SizeSpy` log file generates correctly and the spinner visualization works normally.

---
*PR created automatically by Jules for task [18171869033578840636](https://jules.google.com/task/18171869033578840636) started by @GhostwheeI*